### PR TITLE
Scale <canvas> based on viewport size

### DIFF
--- a/scripts/card.js
+++ b/scripts/card.js
@@ -1,9 +1,5 @@
 export default class Card {
   faceUp = false;
-  x = 0;
-  y = 0;
-  width = 75;
-  height = 100;
   backImg = null;
   frontImg = null;
   suit = null;

--- a/scripts/falling_cards.js
+++ b/scripts/falling_cards.js
@@ -48,7 +48,7 @@ const fallingCards = (canvas, foundations) => {
       movingCard = getNextFallingCard();
     }
 
-    context.drawImage(movingCard.image, movingCard.x, movingCard.y);
+    context.drawImage(movingCard.image, movingCard.x, movingCard.y, movingCard.width, movingCard.height);
 
     // determine next position
     movingCard.x += movingCard.velocity.x;

--- a/scripts/foundation.js
+++ b/scripts/foundation.js
@@ -9,7 +9,7 @@ export default class Foundation extends Stack {
 
   draw(context) {
     if (!this.hasCards) {
-      context.drawImage(this.image, this.x, this.y);
+      context.drawImage(this.image, this.x, this.y, this.width, this.height);
 
       return;
     }
@@ -20,7 +20,7 @@ export default class Foundation extends Stack {
     card.y = this.y;
 
     // only draw the top-most card
-    context.drawImage(card.image, card.x, card.y);
+    context.drawImage(card.image, card.x, card.y, card.width, card.height);
   }
 
   validPlay(card) {

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -69,6 +69,9 @@ const klondike = e => {
   // (e.g. within 500ms) then the interaction counts as a double-click
   let lastOnDownTimestamp = Date.now();
 
+  // stores reference to falling cards animation
+  let interval;
+
   // initialize all places where a card can be placed - https://en.wikipedia.org/wiki/Glossary_of_patience_terms
 
   // "talon" (draw pile)
@@ -162,7 +165,7 @@ const klondike = e => {
 
   const draw = () => {
     // clear previous contents
-    // context.clearRect(0, 0, width, height);
+    context.clearRect(0, 0, canvas.width, canvas.height);
 
     // draw card piles
     talon.draw(context);
@@ -190,9 +193,6 @@ const klondike = e => {
       return count === 13;
     });
   };
-
-  // initial draw
-  draw();
 
   // Event handlers
   const onDown = e => {
@@ -497,7 +497,7 @@ const klondike = e => {
     }
   };
 
-  const onResize = e => {
+  const onResize = () => {
     let windowWidth = window.innerWidth;
     let windowHeight = window.innerHeight;
     let aspectRatio = 4 / 3;
@@ -528,7 +528,7 @@ const klondike = e => {
     let cardMargin = (8 / 605) * tableauWidth;
     let cardOffset = cardMargin * 2;
 
-    let cardWidth = (75 / 605) * tableauWidth;
+    let cardWidth = (77.25 / 605) * tableauWidth;
     let cardHeight = (100 / 454) * tableauHeight;
 
     // console.log(windowWidth, windowHeight, tableauWidth, tableauHeight, margin, cardOffset, cardWidth, cardHeight);
@@ -558,7 +558,7 @@ const klondike = e => {
     waste.y = talon.y;
 
     foundations.forEach((f, i) => {
-      f.x = (windowWidth - windowMargin) - (cardWidth * (i + 1)) - (cardMargin * (i + 1));
+      f.x = (windowWidth - windowMargin) - ((cardWidth + cardMargin) * (i + 1));
       f.y = cardMargin;
     });
 
@@ -568,9 +568,9 @@ const klondike = e => {
     });
 
     // debug
-    let ctx = canvas.getContext('2d');
-    ctx.fillStyle = 'red';
-    ctx.fillRect(windowMargin, 0, tableauWidth, tableauHeight);
+    // let ctx = canvas.getContext('2d');
+    // ctx.fillStyle = 'red';
+    // ctx.fillRect(windowMargin, 0, tableauWidth, tableauHeight);
 
     draw();
   };

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -303,6 +303,9 @@ const klondike = e => {
 
         if (!card.faceUp) {
           card.faceUp = true;
+
+          // TODO: don't allow the same click to both turn over _and_ grab card
+          return;
         }
 
         // break the parent -> child connection so the card(s) are no longer drawn at the source
@@ -321,7 +324,7 @@ const klondike = e => {
       }
     });
 
-    // this should really be called `draw`
+    // update canvas
     draw();
   };
 
@@ -343,6 +346,13 @@ const klondike = e => {
 
   const onUp = e => {
     e.preventDefault();
+
+    if (interval) {
+      window.clearInterval(interval);
+      interval = null;
+
+      // TODO: reset game
+    }
 
     let point = getCoords(e);
 
@@ -526,29 +536,28 @@ const klondike = e => {
 
     // tweak these values as necessary
     let cardMargin = (8 / 605) * tableauWidth;
-    let cardOffset = cardMargin * 2;
+    let cardOffset = cardMargin * 2.5;
 
     let cardWidth = (77.25 / 605) * tableauWidth;
     let cardHeight = (100 / 454) * tableauHeight;
 
-    // console.log(windowWidth, windowHeight, tableauWidth, tableauHeight, margin, cardOffset, cardWidth, cardHeight);
-
     // enumerate over all cards/stacks in order to set their width/height
-    for (let group of [talon, waste, foundations, piles, cards]) {
+    for (let group of [grabbed, talon, waste, foundations, piles, cards]) {
       if (Array.isArray(group)) {
         for (let item of group) {
           item.width = cardWidth;
           item.height = cardHeight;
-
-          if (item.offset) {
-            item.offset = cardOffset;
-          }
+          item.cardOffset = cardOffset;
         }
       } else {
         group.width = cardWidth;
         group.height = cardHeight;
+        group.cardOffset = cardOffset;
       }
     }
+
+    // TODO: option to invert orientation of tableau;
+    // talon/waste on right side, foundations on left side
 
     // update positions of talon, waste, foundations, and piles
     talon.x = windowMargin + cardMargin;
@@ -572,7 +581,10 @@ const klondike = e => {
     // ctx.fillStyle = 'red';
     // ctx.fillRect(windowMargin, 0, tableauWidth, tableauHeight);
 
-    draw();
+    if (!interval) {
+      // update screen if not displaying card waterfall
+      draw();
+    }
   };
 
   // initial draw/resize

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -558,23 +558,43 @@ const klondike = e => {
 
     // TODO: option to invert orientation of tableau;
     // talon/waste on right side, foundations on left side
+    let mirror = true;
 
     // update positions of talon, waste, foundations, and piles
-    talon.x = windowMargin + cardMargin;
-    talon.y = cardMargin;
+    if (mirror) {
+      talon.x = windowWidth - windowMargin - cardMargin - cardWidth;
+      talon.y = cardMargin;
 
-    waste.x = talon.x + cardMargin + cardWidth;
-    waste.y = talon.y;
+      waste.x = talon.x - cardMargin - cardWidth;
+      waste.y = talon.y;
 
-    foundations.forEach((f, i) => {
-      f.x = (windowWidth - windowMargin) - ((cardWidth + cardMargin) * (i + 1));
-      f.y = cardMargin;
-    });
+      foundations.forEach((f, i) => {
+        f.x = windowMargin + cardMargin + (cardWidth + cardMargin) * i;
+        f.y = cardMargin;
+      });
 
-    piles.forEach((p, i) => {
-      p.x = cardWidth * i + (cardMargin * i) + talon.x;
-      p.y = cardHeight + cardMargin * 2;
-    });
+      piles.forEach((p, i) => {
+        p.x = talon.x - (cardWidth + cardMargin) * i;
+        p.y = cardHeight + cardMargin * 2;
+      });
+    } else {
+      talon.x = windowMargin + cardMargin;
+      talon.y = cardMargin;
+
+      waste.x = talon.x + cardMargin + cardWidth;
+      waste.y = talon.y;
+
+      foundations.forEach((f, i) => {
+        f.x = (windowWidth - windowMargin) - ((cardWidth + cardMargin) * (i + 1));
+        f.y = cardMargin;
+      });
+
+      piles.forEach((p, i) => {
+        p.x = (cardWidth + cardMargin) * i + talon.x;
+        p.y = cardHeight + (cardMargin * 2);
+      });
+    }
+
 
     // debug
     // let ctx = canvas.getContext('2d');

--- a/scripts/stack.js
+++ b/scripts/stack.js
@@ -1,7 +1,4 @@
 export default class Stack {
-  width = 75;
-  height = 100;
-  offset = 18;
   child = null;
 
   constructor(type, x, y) {
@@ -50,14 +47,8 @@ export default class Stack {
 
       context.drawImage(card.image, card.x, card.y, card.width, card.height);
 
-      // TODO: extract this magic number; previously `overlapOffset`
-      let offset = this.offset;
-
       // if cards in play piles are still face down, draw them closer together
-      if (!card.faceUp) {
-        // TODO: extract this magic number
-        offset = 3;
-      }
+      let offset = card.faceUp ? this.cardOffset : this.cardOffset / 4;
 
       // set up for next card (if necessary)
       y = y + offset;
@@ -81,11 +72,10 @@ export default class Stack {
     }
 
     let card = this;
-    let offset = card.offset || 18;
 
     do {
-      // cards under other cards only have 18px (`overlapOffset`) of touchable space
-      let height = card.child ? offset : card.height;
+      // cards under other cards only have `cardOffset` of touchable space
+      let height = card.child ? this.cardOffset : card.height;
 
       if (point.x > card.x && point.x < card.x + card.width &&
           point.y > card.y && point.y < card.y + height &&

--- a/scripts/stack.js
+++ b/scripts/stack.js
@@ -1,6 +1,7 @@
 export default class Stack {
   width = 75;
   height = 100;
+  offset = 18;
   child = null;
 
   constructor(type, x, y) {
@@ -47,10 +48,10 @@ export default class Stack {
       card.x = x;
       card.y = y;
 
-      context.drawImage(card.image, card.x, card.y);
+      context.drawImage(card.image, card.x, card.y, card.width, card.height);
 
       // TODO: extract this magic number; previously `overlapOffset`
-      let offset = 18;
+      let offset = this.offset;
 
       // if cards in play piles are still face down, draw them closer together
       if (!card.faceUp) {
@@ -80,7 +81,7 @@ export default class Stack {
     }
 
     let card = this;
-    let offset = 18;
+    let offset = card.offset || 18;
 
     do {
       // cards under other cards only have 18px (`overlapOffset`) of touchable space

--- a/scripts/talon.js
+++ b/scripts/talon.js
@@ -31,8 +31,8 @@ export default class Talon extends Stack {
         context.drawImage(card.image, card.x, card.y, card.width, card.height);
 
         // update offset for next card
-        offset.x += this.cardOffset / 7;
-        offset.y += this.cardOffset / 10;
+        offset.x += this.cardOffset / 8;
+        offset.y += this.cardOffset / 12;
       }
 
       count += 1;

--- a/scripts/talon.js
+++ b/scripts/talon.js
@@ -9,7 +9,7 @@ export default class Talon extends Stack {
 
   draw(context) {
     if (!this.hasCards) {
-      context.drawImage(this.image, this.x, this.y);
+      context.drawImage(this.image, this.x, this.y, this.width, this.height);
 
       return;
     }
@@ -28,7 +28,7 @@ export default class Talon extends Stack {
         card.x = this.x + offset.x;
         card.y = this.y + offset.y;
 
-        context.drawImage(card.image, card.x, card.y);
+        context.drawImage(card.image, card.x, card.y, card.width, card.height);
 
         // update offset for next card
         // TODO: extract these magic numbers

--- a/scripts/talon.js
+++ b/scripts/talon.js
@@ -31,9 +31,8 @@ export default class Talon extends Stack {
         context.drawImage(card.image, card.x, card.y, card.width, card.height);
 
         // update offset for next card
-        // TODO: extract these magic numbers
-        offset.x += 2;
-        offset.y += 1;
+        offset.x += this.cardOffset / 7;
+        offset.y += this.cardOffset / 10;
       }
 
       count += 1;

--- a/scripts/waste.js
+++ b/scripts/waste.js
@@ -27,9 +27,8 @@ export default class Waste extends Stack {
         context.drawImage(card.image, card.x, card.y, card.width, card.height);
 
         // update offset for next card
-        // TODO: extract these magic numbers
-        offset.x += 2;
-        offset.y += 1;
+        offset.x += this.cardOffset / 7;
+        offset.y += this.cardOffset / 10;
       }
 
       // ensure the last card on the stack is drawn

--- a/scripts/waste.js
+++ b/scripts/waste.js
@@ -27,8 +27,8 @@ export default class Waste extends Stack {
         context.drawImage(card.image, card.x, card.y, card.width, card.height);
 
         // update offset for next card
-        offset.x += this.cardOffset / 7;
-        offset.y += this.cardOffset / 10;
+        offset.x += this.cardOffset / 8;
+        offset.y += this.cardOffset / 12;
       }
 
       // ensure the last card on the stack is drawn

--- a/scripts/waste.js
+++ b/scripts/waste.js
@@ -7,8 +7,6 @@ export default class Waste extends Stack {
 
   draw(context) {
     if (!this.hasCards) {
-      // context.drawImage(IMAGES['backs_target'], this.x, this.y);
-
       return;
     }
 
@@ -26,16 +24,17 @@ export default class Waste extends Stack {
       if (Math.floor(count / 8) > drawnCards) {
         drawnCards += 1;
 
-        context.drawImage(card.image, card.x, card.y);
+        context.drawImage(card.image, card.x, card.y, card.width, card.height);
 
         // update offset for next card
+        // TODO: extract these magic numbers
         offset.x += 2;
         offset.y += 1;
       }
 
       // ensure the last card on the stack is drawn
       if (!card.child) {
-        context.drawImage(card.image, card.x, card.y);
+        context.drawImage(card.image, card.x, card.y, card.width, card.height);
       }
 
       count += 1;


### PR DESCRIPTION
Stretch `<canvas>` to the entire window, while keeping playable area aspect ratio.